### PR TITLE
Allow AWS creds to be set through env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 sqscmd
 ------
 
-Helper for using SQS simply in bash scripting. Makes assumptions, like expecting your AWS credentials to be in `~/.s3cfg`.
+Helper for using SQS simply in bash scripting. Makes assumptions, like expecting your AWS credentials to be either in `~/.s3cfg` or exposed as environment variables `$AWSKEY` and `$AWSSECRET`.
 
     sudo npm install -g https://github.com/mapbox/sqscmd/tarball/master
 

--- a/sqscmd
+++ b/sqscmd
@@ -1,12 +1,19 @@
 #!/usr/bin/env node
 
-try {
-    var s3cfg = require('fs').readFileSync(require('path').join(process.env.HOME, '.s3cfg'), 'utf8');
-    var awsKey = s3cfg.match(/access_key = (.*)/)[1];
-    var awsSecret = s3cfg.match(/secret_key = (.*)/)[1];
-} catch(err) {
-    console.warn('Could not read AWS credentials from .s3cfg.');
-    process.exit(1);
+var awsKey, awsSecret;
+
+if (process.env.AWSKEY && process.env.AWSSECRET) {
+    awsKey = process.env.AWSKEY;
+    awsSecret = process.env.AWSSECRET;
+} else {
+    try {
+        var s3cfg = require('fs').readFileSync(require('path').join(process.env.HOME, '.s3cfg'), 'utf8');
+        awsKey = s3cfg.match(/access_key = (.*)/)[1];
+        awsSecret = s3cfg.match(/secret_key = (.*)/)[1];
+    } catch(err) {
+        console.warn('Could not read AWS credentials from .s3cfg or environment.');
+        process.exit(1);
+    }
 }
 
 var argv = process.argv;


### PR DESCRIPTION
Instead of having to use .s3cfg file, let environment variables handle AWS creds. This could help ease some server setup workflows.
